### PR TITLE
Update package versions and refactor repository constructors

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
   <ItemGroup>
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.0" />
-    <PackageVersion Include="Mtd.Core" Version="9.2.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.1" />
+    <PackageVersion Include="Mtd.Core" Version="9.2.1" />
   </ItemGroup>
 </Project>

--- a/Repositories/AsyncEFIdentifiableRepository.cs
+++ b/Repositories/AsyncEFIdentifiableRepository.cs
@@ -1,17 +1,13 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Mtd.Core.Entities;
 using Mtd.Core.Repositories;
-using System.Security.Principal;
 
 namespace Mtd.Infrastructure.EFCore.Repositories
 {
-	public abstract class AsyncEFIdentifiableRepository<T_Identity, T_Entity> : AsyncEFRepository<T_Entity>, IAsyncIdentifiable<T_Identity, T_Entity>
+	public abstract class AsyncEFIdentifiableRepository<T_Identity, T_Entity>(DbContext context) : AsyncEFRepository<T_Entity>(context), IAsyncIdentifiable<T_Identity, T_Entity>
 		where T_Identity : notnull, IComparable<T_Identity>
 		where T_Entity : class, IIdentity<T_Identity>
 	{
-		protected AsyncEFIdentifiableRepository(DbContext context) : base(context)
-		{
-		}
 
 		#region IAsyncIdentifiable
 

--- a/Repositories/AsyncEFRepository.cs
+++ b/Repositories/AsyncEFRepository.cs
@@ -6,9 +6,8 @@ using System.Linq.Expressions;
 
 namespace Mtd.Infrastructure.EFCore.Repositories
 {
-	public abstract class AsyncEFRepository<T> : EFRepository<T>, IAsyncReadable<T, IReadOnlyCollection<T>>, IAsyncWriteable<T, IReadOnlyCollection<T>> where T : class
+	public abstract class AsyncEFRepository<T>(DbContext context) : EFRepository<T>(context), IAsyncReadable<T, IReadOnlyCollection<T>>, IAsyncWriteable<T, IReadOnlyCollection<T>> where T : class
 	{
-		protected AsyncEFRepository(DbContext context) : base(context) { }
 
 		#region IAsyncReadable
 

--- a/Repositories/SynchronousEFIdentifiableRepository.cs
+++ b/Repositories/SynchronousEFIdentifiableRepository.cs
@@ -4,11 +4,10 @@ using Mtd.Core.Repositories;
 
 namespace Mtd.Infrastructure.EFCore.Repositories
 {
-	public abstract class SynchronousEFIdentifiableRepository<T_Identity, T_Entity> : SynchronousEFRepository<T_Entity>, IIdentifiable<T_Identity, T_Entity>
+	public abstract class SynchronousEFIdentifiableRepository<T_Identity, T_Entity>(DbContext context) : SynchronousEFRepository<T_Entity>(context), IIdentifiable<T_Identity, T_Entity>
 		where T_Identity : IComparable<T_Identity>
 		where T_Entity : class, IIdentity<T_Identity>
 	{
-		protected SynchronousEFIdentifiableRepository(DbContext context) : base(context) { }
 		public T_Entity GetByIdentity(T_Identity identity) => _dbSet
 			.Find(identity) ?? throw new InvalidOperationException($"{identity} not found.");
 		public T_Entity? GetByIdentityOrDefault(T_Identity identity) => _dbSet

--- a/Repositories/SynchronousEFRepository.cs
+++ b/Repositories/SynchronousEFRepository.cs
@@ -6,9 +6,8 @@ using System.Linq.Expressions;
 
 namespace Mtd.Infrastructure.EFCore.Repositories
 {
-	public abstract class SynchronousEFRepository<T> : EFRepository<T>, IReadable<T, IReadOnlyCollection<T>>, IWriteable<T, IReadOnlyCollection<T>> where T : class
+	public abstract class SynchronousEFRepository<T>(DbContext context) : EFRepository<T>(context), IReadable<T, IReadOnlyCollection<T>>, IWriteable<T, IReadOnlyCollection<T>> where T : class
 	{
-		protected SynchronousEFRepository(DbContext context) : base(context) { }
 
 		#region IReadable
 		public bool All(Expression<Func<T, bool>> predicate) => Query().All(predicate);


### PR DESCRIPTION
Updated `Directory.Packages.props` to change versions of:
- `Microsoft.EntityFrameworkCore` from `9.0.0` to `9.0.1`
- `Microsoft.EntityFrameworkCore.Analyzers` from `9.0.0` to `9.0.1`
- `Mtd.Core` from `9.2.0` to `9.2.1`

Refactored repository classes to use constructor parameters for `DbContext`:
- `AsyncEFIdentifiableRepository.cs`
- `AsyncEFRepository.cs`
- `SynchronousEFIdentifiableRepository.cs`
- `SynchronousEFRepository.cs`

Removed `using System.Security.Principal;` from `AsyncEFIdentifiableRepository.cs`.